### PR TITLE
feat: Implemented a sleek, searchable file list in the Real-Debrid tab

### DIFF
--- a/Dionysus/DebridFilesView.swift
+++ b/Dionysus/DebridFilesView.swift
@@ -26,8 +26,17 @@ struct DebridFilesView: View {
                         }
                     }
                 } else {
+                    HStack {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundColor(.white.opacity(0.5))
+                        TextField("Search...", text: $viewModel.searchText)
+                            .foregroundColor(.white)
+                    }
+                    .glassmorphicStyle()
+                    .padding(.horizontal)
+
                     List {
-                        ForEach(viewModel.torrents) { torrent in
+                        ForEach(viewModel.filteredTorrents) { torrent in
                             HStack {
                                 VStack(alignment: .leading) {
                                     Text(torrent.filename)
@@ -49,8 +58,10 @@ struct DebridFilesView: View {
                             }
                         }
                         .onDelete(perform: deleteItems)
+                        .listRowBackground(Color.clear)
                     }
                     .listStyle(.plain)
+                    .background(Color.clear)
                     .background(GeometryReader {
                         Color.clear.preference(key: ScrollOffsetPreferenceKey.self, value: $0.frame(in: .named("scroll")).minY)
                     })

--- a/Dionysus/DebridFilesViewModel.swift
+++ b/Dionysus/DebridFilesViewModel.swift
@@ -6,10 +6,16 @@ class DebridFilesViewModel: ObservableObject {
     @Published var torrents: [RealDebridTorrent] = []
     @Published var isLoading = false
     @Published var errorMessage: String?
+    @Published var searchText = ""
 
     private var currentPage = 1
     private var isFetching = false
     private var hasMorePages = true
+
+    var filteredTorrents: [RealDebridTorrent] {
+        guard !searchText.isEmpty else { return torrents }
+        return torrents.filter { $0.filename.localizedCaseInsensitiveContains(searchText) }
+    }
 
     func fetchTorrents(forceRefresh: Bool = false) async {
         guard !isFetching, hasMorePages || forceRefresh else { return }

--- a/Dionysus/GlassMorphicStyle.swift
+++ b/Dionysus/GlassMorphicStyle.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct GlassmorphicStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(
+                .ultraThinMaterial,
+                in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(.white.opacity(0.2), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 4)
+    }
+}
+
+extension View {
+    func glassmorphicStyle() -> some View {
+        self.modifier(GlassmorphicStyle())
+    }
+}

--- a/DionysusTests/DebridFilesViewModelTests.swift
+++ b/DionysusTests/DebridFilesViewModelTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import Dionysus
+
+@MainActor
+struct DebridFilesViewModelTests {
+
+    var viewModel: DebridFilesViewModel!
+
+    @before @MainActor func setup() {
+        viewModel = DebridFilesViewModel()
+        viewModel.torrents = [
+            RealDebridTorrent(id: "1", filename: "Test File 1.mkv", bytes: 100, status: "downloaded"),
+            RealDebridTorrent(id: "2", filename: "Another Test File.mp4", bytes: 200, status: "downloading"),
+            RealDebridTorrent(id: "3", filename: "Yet Another File.avi", bytes: 300, status: "seeding")
+        ]
+    }
+
+    @Test func testFilterTorrents() {
+        viewModel.searchText = "Test"
+        #expect(viewModel.filteredTorrents.count == 2)
+        #expect(viewModel.filteredTorrents.allSatisfy { $0.filename.contains("Test") })
+    }
+
+    @Test func testFilterTorrents_caseInsensitive() {
+        viewModel.searchText = "test"
+        #expect(viewModel.filteredTorrents.count == 2)
+        #expect(viewModel.filteredTorrents.allSatisfy { $0.filename.lowercased().contains("test") })
+    }
+
+    @Test func testFilterTorrents_noResults() {
+        viewModel.searchText = "xyz"
+        #expect(viewModel.filteredTorrents.isEmpty)
+    }
+
+    @Test func testFilterTorrents_emptySearchText() {
+        viewModel.searchText = ""
+        #expect(viewModel.filteredTorrents.count == 3)
+    }
+}


### PR DESCRIPTION
This commit introduces a search bar to the Debrid files view, allowing users to easily filter their torrents by filename.

- Added a search text field with a modern glassmorphic style.
- Implemented filtering logic in the `DebridFilesViewModel` to enable real-time search.
- Updated the `DebridFilesView` to display the filtered results.
- Added unit tests to ensure the filtering logic is correct and robust.