### PR TITLE
Add server warm-up ping on launch and auto-retry with backoff in SourcesView

### DIFF
--- a/Dionysus/MovieLibraryApp.swift
+++ b/Dionysus/MovieLibraryApp.swift
@@ -8,6 +8,9 @@ struct DionysusApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .task {
+                    await APIService.shared.pingServer()
+                }
         }
     }
 }
@@ -80,23 +83,40 @@ enum WatchStatus {
 class LibraryViewModel: ObservableObject {
     @Published var torrents: [Torrent] = []
     @Published var isLoading = false
+    @Published var isWakingServer = false
     @Published var errorMessage: String?
     @Published var addState: LoadingState = .idle
     @Published var existingTorrentHashes: Set<String> = []
 
     func fetchTorrents(for query: String, forceRefresh: Bool = false) async {
         isLoading = true
+        isWakingServer = false
         errorMessage = nil
-        do {
-            async let searchResult = APIService.shared.searchTorrents(query: query, forceRefresh: forceRefresh)
-            async let hashesResult = APIService.shared.fetchUserTorrentHashes()
-            let (fetchedTorrents, fetchedHashes) = try await (searchResult, hashesResult)
-            self.torrents = fetchedTorrents
-            self.existingTorrentHashes = fetchedHashes
-            HapticManager.shared.success()
-        } catch {
-            self.errorMessage = "Failed to fetch sources."
+
+        let retryDelays: [UInt64] = [2_000_000_000, 4_000_000_000, 8_000_000_000]
+
+        for attempt in 0..<(retryDelays.count + 1) {
+            if attempt > 0 {
+                isWakingServer = true
+                try? await Task.sleep(nanoseconds: retryDelays[attempt - 1])
+            }
+            do {
+                async let searchResult = APIService.shared.searchTorrents(query: query, forceRefresh: forceRefresh)
+                async let hashesResult = APIService.shared.fetchUserTorrentHashes()
+                let (fetchedTorrents, fetchedHashes) = try await (searchResult, hashesResult)
+                self.torrents = fetchedTorrents
+                self.existingTorrentHashes = fetchedHashes
+                isWakingServer = false
+                HapticManager.shared.success()
+                isLoading = false
+                return
+            } catch {
+                // continue to next retry
+            }
         }
+
+        isWakingServer = false
+        self.errorMessage = "Failed to fetch sources."
         isLoading = false
     }
 
@@ -811,7 +831,17 @@ struct SourcesView: View {
                 .padding(.top)
 
                 Group {
-                    if viewModel.isLoading { ProgressView() }
+                    if viewModel.isLoading {
+                        VStack(spacing: 12) {
+                            ProgressView()
+                            if viewModel.isWakingServer {
+                                Text("Waking up server...")
+                                    .font(.custom("Eurostile-Regular", size: 14))
+                                    .foregroundColor(.secondary)
+                                    .transition(.opacity.animation(.easeIn))
+                            }
+                        }
+                    }
                     else if let errorMessage = viewModel.errorMessage { ErrorView(message: errorMessage) { Task { await viewModel.fetchTorrents(for: finalSearchQuery) } } }
                     else if filteredTorrents.isEmpty { ContentUnavailableView("No Sources Found", systemImage: "magnifyingglass") }
                     else {

--- a/Dionysus/SharedCode.swift
+++ b/Dionysus/SharedCode.swift
@@ -550,6 +550,13 @@ class APIService {
         }
     }
 
+    func pingServer() async {
+        guard let url = URL(string: "\(dionysusServerBaseURL)/health") else { return }
+        let request = URLRequest(url: url, timeoutInterval: 30)
+        _ = try? await URLSession.shared.data(for: request)
+        print("🏓 [API] Server ping complete")
+    }
+
     func fetchWatchProviders(for media: any Media) async throws -> WatchProviderCountryResult? {
         let mediaType = media is Movie ? "movie" : "tv"
         let url = URL(string: "\(baseUrl)/\(mediaType)/\(media.id)/watch/providers?api_key=\(SettingsManager.shared.tmdbApiKey)")!


### PR DESCRIPTION
- Fire a silent GET /health ping to the Dionysus server the moment the app
  opens so Railway has time to wake the server before the user navigates
  to Sources (30s timeout to cover cold start window)
- LibraryViewModel.fetchTorrents now retries up to 3 times with exponential
  backoff (2s, 4s, 8s) instead of immediately surfacing an error to the user
- SourcesView shows "Waking up server..." below the spinner during retry
  attempts so the user knows what's happening rather than seeing a failure

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg