### PR TITLE
File inspection sheet with subtitle detection + API key fix

### DIFF
--- a/Dionysus/FilesDetailView.swift
+++ b/Dionysus/FilesDetailView.swift
@@ -18,12 +18,25 @@ struct FileDetailsView: View {
                     }
                 } else if let torrentInfo = viewModel.torrentInfo {
                     List(torrentInfo.files) { file in
-                        VStack(alignment: .leading) {
-                            Text(file.path)
-                                .font(.headline)
-                            Text("Size: \(formatFileSize(Int64(file.bytes)))")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
+                        HStack(spacing: 10) {
+                            Image(systemName: file.isSubtitle ? "captions.bubble.fill" : "doc.fill")
+                                .foregroundColor(file.isSubtitle ? .green : .secondary)
+                                .frame(width: 20)
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(URL(fileURLWithPath: file.path).lastPathComponent)
+                                    .font(.headline)
+                                    .lineLimit(2)
+                                HStack {
+                                    Text("Size: \(formatFileSize(Int64(file.bytes)))")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                    if let lang = file.subtitleLanguage {
+                                        Text("• \(lang)")
+                                            .font(.subheadline)
+                                            .foregroundColor(.green)
+                                    }
+                                }
+                            }
                         }
                     }
                 } else {

--- a/Dionysus/MovieLibraryApp.swift
+++ b/Dionysus/MovieLibraryApp.swift
@@ -90,6 +90,8 @@ class LibraryViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var addState: LoadingState = .idle
     @Published var existingTorrentHashes: Set<String> = []
+    @Published var pendingTorrentId: String? = nil
+    @Published var pendingTorrentInfo: RealDebridTorrentInfo? = nil
 
     func fetchTorrents(for query: String, forceRefresh: Bool = false) async {
         isLoading = true
@@ -130,18 +132,38 @@ class LibraryViewModel: ObservableObject {
         isLoading = false
     }
 
-    func addTorrent(magnet: String) async {
+    func startAddTorrent(magnet: String) async {
         addState = .loading
         do {
-            try await APIService.shared.addAndSelectTorrent(magnet: magnet)
-            addState = .success
-            HapticManager.shared.success()
-            if let newHash = Torrent(name: "", size: nil, seeders: nil, leechers: nil, magnet: magnet, quality: nil, provider: nil).infoHash {
-                existingTorrentHashes.insert(newHash)
-            }
+            let (id, info) = try await APIService.shared.addMagnetForInspection(magnet: magnet)
+            pendingTorrentId = id
+            pendingTorrentInfo = info
+            addState = .idle
         } catch {
             addState = .error
         }
+    }
+
+    func confirmTorrent() async {
+        guard let id = pendingTorrentId, let info = pendingTorrentInfo else { return }
+        pendingTorrentId = nil
+        pendingTorrentInfo = nil
+        addState = .loading
+        do {
+            try await APIService.shared.confirmTorrentSelection(id: id)
+            existingTorrentHashes.insert(info.hash.lowercased())
+            addState = .success
+            HapticManager.shared.success()
+        } catch {
+            addState = .error
+        }
+    }
+
+    func cancelPendingTorrent() async {
+        guard let id = pendingTorrentId else { return }
+        pendingTorrentId = nil
+        pendingTorrentInfo = nil
+        try? await APIService.shared.deleteTorrent(id: id)
     }
 }
 
@@ -857,7 +879,7 @@ struct SourcesView: View {
                     else {
                         List(filteredTorrents) { torrent in
                             let isAdded = torrent.infoHash.flatMap { viewModel.existingTorrentHashes.contains($0) } ?? false
-                            TorrentRowView(torrent: torrent, isAlreadyAdded: isAdded) { magnet in Task { await viewModel.addTorrent(magnet: magnet) } }
+                            TorrentRowView(torrent: torrent, isAlreadyAdded: isAdded) { magnet in Task { await viewModel.startAddTorrent(magnet: magnet) } }
                         }
                         .listStyle(.plain)
                     }
@@ -892,6 +914,14 @@ struct SourcesView: View {
             .onChange(of: viewModel.addState) { if viewModel.addState == .success {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { viewModel.addState = .idle }
             }}
+            .sheet(item: $viewModel.pendingTorrentInfo) { info in
+                TorrentFileInspectionView(info: info) {
+                    Task { await viewModel.confirmTorrent() }
+                } onCancel: {
+                    Task { await viewModel.cancelPendingTorrent() }
+                }
+                .presentationDetents([.medium, .large])
+            }
             if viewModel.addState != .idle { StatusOverlayView(addState: $viewModel.addState) }
         }
     }
@@ -1431,6 +1461,108 @@ class ImageCache {
 
 extension String: @retroactive Identifiable {
     public var id: String { self }
+}
+
+struct TorrentFileInspectionView: View {
+    let info: RealDebridTorrentInfo
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+
+    private var subtitleFiles: [RealDebridFile] { info.files.filter { $0.isSubtitle } }
+    private var otherFiles: [RealDebridFile] { info.files.filter { !$0.isSubtitle } }
+    private var detectedLanguages: [String] {
+        Array(Set(subtitleFiles.compactMap { $0.subtitleLanguage })).sorted()
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    if subtitleFiles.isEmpty {
+                        Label("No subtitles found in this torrent", systemImage: "captions.bubble")
+                            .foregroundColor(.secondary)
+                    } else {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label("Subtitles detected", systemImage: "captions.bubble.fill")
+                                .foregroundColor(.green)
+                            if !detectedLanguages.isEmpty {
+                                Text(detectedLanguages.joined(separator: " • "))
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            } else {
+                                Text("\(subtitleFiles.count) subtitle file(s) — language unknown")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                } header: {
+                    Text("Subtitles")
+                }
+
+                if !subtitleFiles.isEmpty {
+                    Section("Subtitle Files") {
+                        ForEach(subtitleFiles) { file in
+                            HStack(spacing: 10) {
+                                Image(systemName: "captions.bubble.fill")
+                                    .foregroundColor(.green)
+                                    .frame(width: 20)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(URL(fileURLWithPath: file.path).lastPathComponent)
+                                        .font(.custom("Eurostile-Regular", size: 13))
+                                    if let lang = file.subtitleLanguage {
+                                        Text(lang)
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section("Video & Other Files") {
+                    ForEach(otherFiles) { file in
+                        HStack(spacing: 10) {
+                            Image(systemName: "doc.fill")
+                                .foregroundColor(.secondary)
+                                .frame(width: 20)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(URL(fileURLWithPath: file.path).lastPathComponent)
+                                    .font(.custom("Eurostile-Regular", size: 13))
+                                    .lineLimit(2)
+                                Text(formatBytes(file.bytes))
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(info.filename)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { onCancel() }
+                        .foregroundColor(.red)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add to Library") { onConfirm() }
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private func formatBytes(_ bytes: Int) -> String {
+        let gb = Double(bytes) / 1_073_741_824
+        if gb >= 1 { return String(format: "%.2f GB", gb) }
+        let mb = Double(bytes) / 1_048_576
+        if mb >= 1 { return String(format: "%.2f MB", mb) }
+        return "\(bytes) B"
+    }
 }
 
 #if os(iOS)

--- a/Dionysus/SharedCode.swift
+++ b/Dionysus/SharedCode.swift
@@ -257,10 +257,44 @@ struct RealDebridFile: Codable, Identifiable, Hashable {
     let selected: Int
 }
 
-struct RealDebridTorrentInfo: Codable {
+extension RealDebridFile {
+    private static let subtitleExtensions: Set<String> = [
+        ".srt", ".vtt", ".ass", ".ssa", ".sub", ".idx", ".smi", ".ttml", ".sup"
+    ]
+
+    var isSubtitle: Bool {
+        let lower = path.lowercased()
+        return RealDebridFile.subtitleExtensions.contains { lower.hasSuffix($0) }
+    }
+
+    var subtitleLanguage: String? {
+        guard isSubtitle else { return nil }
+        let base = URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent.lowercased()
+        let parts = base.components(separatedBy: CharacterSet(charactersIn: "._- "))
+        let map: [String: String] = [
+            "english": "English", "eng": "English", "en": "English",
+            "french": "French", "fre": "French", "fra": "French", "fr": "French",
+            "spanish": "Spanish", "spa": "Spanish", "es": "Spanish",
+            "german": "German", "ger": "German", "deu": "German", "de": "German",
+            "portuguese": "Portuguese", "por": "Portuguese", "pt": "Portuguese",
+            "italian": "Italian", "ita": "Italian", "it": "Italian",
+            "dutch": "Dutch", "nld": "Dutch", "nl": "Dutch",
+            "japanese": "Japanese", "jpn": "Japanese", "ja": "Japanese",
+            "korean": "Korean", "kor": "Korean", "ko": "Korean",
+            "chinese": "Chinese", "chi": "Chinese", "zho": "Chinese", "zh": "Chinese",
+            "arabic": "Arabic", "ara": "Arabic", "ar": "Arabic",
+            "russian": "Russian", "rus": "Russian", "ru": "Russian",
+        ]
+        return parts.compactMap { map[$0] }.first
+    }
+}
+
+struct RealDebridTorrentInfo: Codable, Identifiable {
     let id: String
     let filename: String
+    let hash: String
     let bytes: Int
+    let status: String
     let files: [RealDebridFile]
 }
 
@@ -485,6 +519,16 @@ class APIService {
         print("[API] Files selected successfully.")
     }
 
+    func addMagnetForInspection(magnet: String) async throws -> (torrentId: String, info: RealDebridTorrentInfo) {
+        let added = try await addMagnetToRealDebrid(magnet: magnet)
+        let info = try await waitForFileSelection(id: added.id)
+        return (added.id, info)
+    }
+
+    func confirmTorrentSelection(id: String) async throws {
+        try await selectTorrentFiles(torrentId: id)
+    }
+
     private func addMagnetToRealDebrid(magnet: String) async throws -> RealDebridAddTorrentResponse {
         let url = URL(string: "https://api.real-debrid.com/rest/1.0/torrents/addMagnet")!
         var request = URLRequest(url: url)
@@ -534,6 +578,17 @@ class APIService {
             print("[RD-API] Select Files error: \(error.localizedDescription)")
             throw error
         }
+    }
+
+    private func waitForFileSelection(id: String) async throws -> RealDebridTorrentInfo {
+        for _ in 0..<15 {
+            let info = try await fetchTorrentInfo(id: id)
+            if info.status != "magnet_conversion" {
+                return info
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        throw APIError.serverError(service: "Real-Debrid", statusCode: 408)
     }
 
     func fetchMovie(id: Int) async throws -> Movie {

--- a/Dionysus/SharedCode.swift
+++ b/Dionysus/SharedCode.swift
@@ -572,7 +572,7 @@ class APIService {
     func fetchTorrentInfo(id: String) async throws -> RealDebridTorrentInfo {
         let url = URL(string: "https://api.real-debrid.com/rest/1.0/torrents/info/\(id)")!
         var request = URLRequest(url: url)
-        request.setValue("Bearer \(Secrets.realDebridApiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(SettingsManager.shared.realDebridApiKey)", forHTTPHeaderField: "Authorization")
 
         let (data, response) = try await URLSession.shared.data(for: request)
 


### PR DESCRIPTION
## Summary

- **Bug fix:** `fetchTorrentInfo` was using `Secrets.realDebridApiKey` instead of `SettingsManager.shared.realDebridApiKey` — the only Real-Debrid call with this mistake, causing "API key invalid" whenever a torrent was tapped in the Files view
- **Pre-add file inspection sheet:** Tapping "Add" on a torrent now shows a confirmation sheet before committing, letting you see exactly what files are in the torrent and what subtitle languages are included
- **Subtitle detection in Files view:** `FilesDetailView` (existing library) also now shows subtitle icons and detected language inline

## How the new add flow works

1. Tap "Add" → spinner while magnet is sent to Real-Debrid and file list loads
2. Sheet slides up showing:
   - **Subtitles banner** — green with detected languages (e.g. "English • French") or gray "No subtitles found"
   - **Subtitle Files** section with language labels
   - **Video & Other Files** section with sizes
3. **"Add to Library"** → confirms, selects all files, success checkmark as before
4. **"Cancel"** → dismisses and auto-deletes the torrent from RD so nothing is left dangling

## Test plan

- [ ] Tap a torrent row in Sources — confirm spinner appears then inspection sheet slides up
- [ ] Verify subtitle section shows correct languages for a known release with English subs
- [ ] Verify "No subtitles found" shows for a release without subtitle files
- [ ] Confirm → torrent appears in Files tab and success overlay shows
- [ ] Cancel → torrent does NOT appear in Real-Debrid (auto-cleaned up)
- [ ] Tap a torrent in the Files tab — confirm it opens without "API key invalid" error
- [ ] Verify subtitle files in FilesDetailView show green icon and language label

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg)_