### PR TITLE
Video preview + file inspection sheet improvements

### DIFF
--- a/Dionysus/MovieLibraryApp.swift
+++ b/Dionysus/MovieLibraryApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import CoreHaptics
 import PencilKit
+import AVKit
 
 @main
 struct DionysusApp: App {
@@ -92,6 +93,7 @@ class LibraryViewModel: ObservableObject {
     @Published var existingTorrentHashes: Set<String> = []
     @Published var pendingTorrentId: String? = nil
     @Published var pendingTorrentInfo: RealDebridTorrentInfo? = nil
+    private var hasSelectedFiles = false
 
     func fetchTorrents(for query: String, forceRefresh: Bool = false) async {
         isLoading = true
@@ -144,13 +146,37 @@ class LibraryViewModel: ObservableObject {
         }
     }
 
+    func loadPreviewURL() async -> URL? {
+        guard let id = pendingTorrentId, let info = pendingTorrentInfo else { return nil }
+        do {
+            if !hasSelectedFiles {
+                try await APIService.shared.confirmTorrentSelection(id: id)
+                hasSelectedFiles = true
+            }
+            let downloaded = try await APIService.shared.pollUntilDownloaded(id: id)
+            // Pick the link for the largest non-subtitle file
+            let videoIndex = downloaded.files.enumerated()
+                .filter { !$0.element.isSubtitle && $0.element.bytes > 0 }
+                .max(by: { $0.element.bytes < $1.element.bytes })?.offset ?? 0
+            guard !downloaded.links.isEmpty else { return nil }
+            let link = downloaded.links[min(videoIndex, downloaded.links.count - 1)]
+            return try await APIService.shared.unrestrict(link: link)
+        } catch {
+            return nil
+        }
+    }
+
     func confirmTorrent() async {
         guard let id = pendingTorrentId, let info = pendingTorrentInfo else { return }
+        let alreadySelected = hasSelectedFiles
         pendingTorrentId = nil
         pendingTorrentInfo = nil
+        hasSelectedFiles = false
         addState = .loading
         do {
-            try await APIService.shared.confirmTorrentSelection(id: id)
+            if !alreadySelected {
+                try await APIService.shared.confirmTorrentSelection(id: id)
+            }
             existingTorrentHashes.insert(info.hash.lowercased())
             addState = .success
             HapticManager.shared.success()
@@ -163,6 +189,7 @@ class LibraryViewModel: ObservableObject {
         guard let id = pendingTorrentId else { return }
         pendingTorrentId = nil
         pendingTorrentInfo = nil
+        hasSelectedFiles = false
         try? await APIService.shared.deleteTorrent(id: id)
     }
 }
@@ -915,12 +942,13 @@ struct SourcesView: View {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { viewModel.addState = .idle }
             }}
             .sheet(item: $viewModel.pendingTorrentInfo) { info in
-                TorrentFileInspectionView(info: info) {
-                    Task { await viewModel.confirmTorrent() }
-                } onCancel: {
-                    Task { await viewModel.cancelPendingTorrent() }
-                }
-                .presentationDetents([.medium, .large])
+                TorrentFileInspectionView(
+                    info: info,
+                    onConfirm: { Task { await viewModel.confirmTorrent() } },
+                    onCancel: { Task { await viewModel.cancelPendingTorrent() } },
+                    onPreview: { await viewModel.loadPreviewURL() }
+                )
+                .presentationDetents([.large])
             }
             if viewModel.addState != .idle { StatusOverlayView(addState: $viewModel.addState) }
         }
@@ -1467,6 +1495,7 @@ struct TorrentFileInspectionView: View {
     let info: RealDebridTorrentInfo
     let onConfirm: () -> Void
     let onCancel: () -> Void
+    let onPreview: () async -> URL?
 
     private var subtitleFiles: [RealDebridFile] { info.files.filter { $0.isSubtitle } }
     private var otherFiles: [RealDebridFile] { info.files.filter { !$0.isSubtitle } }
@@ -1474,9 +1503,53 @@ struct TorrentFileInspectionView: View {
         Array(Set(subtitleFiles.compactMap { $0.subtitleLanguage })).sorted()
     }
 
+    private enum PreviewStatus { case idle, loading, ready, failed }
+    @State private var previewStatus: PreviewStatus = .idle
+    @State private var player: AVPlayer? = nil
+
     var body: some View {
         NavigationStack {
             List {
+                Section("Preview") {
+                    switch previewStatus {
+                    case .idle:
+                        Button {
+                            Task {
+                                previewStatus = .loading
+                                if let url = await onPreview() {
+                                    player = AVPlayer(url: url)
+                                    player?.play()
+                                    previewStatus = .ready
+                                } else {
+                                    previewStatus = .failed
+                                }
+                            }
+                        } label: {
+                            Label("Load Preview", systemImage: "play.circle.fill")
+                                .font(.custom("Eurostile-Regular", size: 16))
+                        }
+                    case .loading:
+                        HStack(spacing: 12) {
+                            ProgressView().scaleEffect(0.85)
+                            Text("Preparing preview — this may take a moment...")
+                                .font(.custom("Eurostile-Regular", size: 14))
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    case .ready:
+                        if let player {
+                            VideoPlayer(player: player)
+                                .frame(height: 210)
+                                .cornerRadius(10)
+                                .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+                        }
+                    case .failed:
+                        Label("Could not load preview — torrent may still be downloading", systemImage: "exclamationmark.triangle")
+                            .font(.custom("Eurostile-Regular", size: 13))
+                            .foregroundColor(.orange)
+                    }
+                }
+
                 Section {
                     if subtitleFiles.isEmpty {
                         Label("No subtitles found in this torrent", systemImage: "captions.bubble")
@@ -1554,6 +1627,7 @@ struct TorrentFileInspectionView: View {
             }
         }
         .preferredColorScheme(.dark)
+        .onDisappear { player?.pause() }
     }
 
     private func formatBytes(_ bytes: Int) -> String {

--- a/Dionysus/SharedCode.swift
+++ b/Dionysus/SharedCode.swift
@@ -295,7 +295,12 @@ struct RealDebridTorrentInfo: Codable, Identifiable {
     let hash: String
     let bytes: Int
     let status: String
+    let links: [String]
     let files: [RealDebridFile]
+}
+
+struct RealDebridUnrestrictResponse: Codable {
+    let download: String
 }
 
 enum APIError: LocalizedError {
@@ -589,6 +594,42 @@ class APIService {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
         }
         throw APIError.serverError(service: "Real-Debrid", statusCode: 408)
+    }
+
+    func pollUntilDownloaded(id: String) async throws -> RealDebridTorrentInfo {
+        let terminalErrors: Set<String> = ["error", "dead", "virus", "magnet_error"]
+        for _ in 0..<30 {
+            let info = try await fetchTorrentInfo(id: id)
+            if info.status == "downloaded" { return info }
+            if terminalErrors.contains(info.status) {
+                throw APIError.serverError(service: "Real-Debrid", statusCode: 500)
+            }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        throw APIError.serverError(service: "Real-Debrid", statusCode: 408)
+    }
+
+    func unrestrict(link: String) async throws -> URL {
+        let url = URL(string: "https://api.real-debrid.com/rest/1.0/unrestrict/link")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(SettingsManager.shared.realDebridApiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let safeLink = link.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+        request.httpBody = "link=\(safeLink)".data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse(service: "Real-Debrid")
+        }
+        if httpResponse.statusCode != 200 {
+            throw APIError.from(httpResponse: httpResponse, data: data, service: "Real-Debrid")
+        }
+        let result = try JSONDecoder().decode(RealDebridUnrestrictResponse.self, from: data)
+        guard let downloadURL = URL(string: result.download) else {
+            throw APIError.decodingFailed(type: "RealDebridUnrestrictResponse")
+        }
+        return downloadURL
     }
 
     func fetchMovie(id: Int) async throws -> Movie {


### PR DESCRIPTION
## Summary

- **Video preview in inspection sheet** — tap "Load Preview" before committing a torrent to your library to stream a snippet directly in the app
- **Smart file selection** — picks the link for the largest non-subtitle file so you get the main video, not a subtitle track
- **Double-confirm guard** — if you load a preview (which selects files on RD) then tap "Add to Library", the file selection step is skipped to avoid redundant API calls
- **Clean cancel** — dismissing after a preview still deletes the torrent from RD

## How preview works

1. Tap "Load Preview" in the inspection sheet
2. App selects files on Real-Debrid (triggering download / cache lookup)
3. Polls until `status = "downloaded"` (2s intervals, up to 60s — instant for cached content)
4. Unrestricts the best video link via `POST /unrestrict/link`
5. `AVPlayer` plays the stream inline in the sheet
6. Tap "Add to Library" to keep it, or "Cancel" to delete it from RD

## Test plan

- [ ] Tap "Add" on a well-seeded torrent — preview loads within a few seconds
- [ ] Video plays inline in the sheet without leaving the app
- [ ] "Add to Library" after previewing → success overlay, torrent appears in Files tab
- [ ] "Cancel" after previewing → torrent is removed from Real-Debrid
- [ ] Dismiss sheet mid-preview → video stops playing
- [ ] Slow/unseeded torrent → "Could not load preview" message after timeout

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg)_