### PR TITLE
Delete orphaned RD torrent on sheet swipe-dismiss

### DIFF
--- a/Dionysus/MovieLibraryApp.swift
+++ b/Dionysus/MovieLibraryApp.swift
@@ -941,7 +941,9 @@ struct SourcesView: View {
             .onChange(of: viewModel.addState) { if viewModel.addState == .success {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { viewModel.addState = .idle }
             }}
-            .sheet(item: $viewModel.pendingTorrentInfo) { info in
+            .sheet(item: $viewModel.pendingTorrentInfo, onDismiss: {
+                Task { await viewModel.cancelPendingTorrent() }
+            }) { info in
                 TorrentFileInspectionView(
                     info: info,
                     onConfirm: { Task { await viewModel.confirmTorrent() } },


### PR DESCRIPTION
## Summary

When the file inspection sheet is swiped down to dismiss (instead of tapping Cancel), the torrent was left on Real-Debrid in `waiting_files_selection` state. This adds an `onDismiss` handler to clean it up automatically.

## How it works

- **Swipe dismiss** → `onDismiss` fires, `pendingTorrentId` still set → deletes from RD
- **Tap "Add to Library"** → `confirmTorrent()` clears `pendingTorrentId` first → `onDismiss` is a no-op
- **Tap "Cancel"** → `cancelPendingTorrent()` clears `pendingTorrentId` and deletes → `onDismiss` is a no-op

## Test plan

- [ ] Add a torrent, open inspection sheet, swipe down — verify torrent does NOT appear in Real-Debrid
- [ ] Add a torrent, tap "Add to Library" — verify torrent IS added and no duplicate delete is attempted
- [ ] Add a torrent, tap "Cancel" — verify torrent is removed from RD (existing behaviour unchanged)

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg)_