### PR TITLE
Health indicators for failed/stuck torrents in Files view

### DIFF
--- a/Dionysus/DebridFilesView.swift
+++ b/Dionysus/DebridFilesView.swift
@@ -68,17 +68,28 @@ struct DebridFilesView: View {
                 Button(action: {
                     selectedTorrent = torrent
                 }) {
-                    HStack {
-                        VStack(alignment: .leading) {
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 2) {
                             Text(torrent.filename)
                                 .font(.headline)
-                            Text("Size: \(formatFileSize(Int64(torrent.bytes)))")
+                                .lineLimit(2)
+                            Text(formatFileSize(Int64(torrent.bytes)))
                                 .font(.subheadline)
-                            Text("Status: \(torrent.status)")
-                                .font(.subheadline)
-                                .foregroundColor(statusColor(for: torrent.status))
+                                .foregroundColor(.secondary)
+                            Text(torrent.statusLabel)
+                                .font(.caption)
+                                .foregroundColor(torrent.statusColor)
                         }
                         Spacer()
+                        if torrent.isFailed {
+                            Image(systemName: "exclamationmark.circle.fill")
+                                .foregroundColor(.red)
+                                .font(.title3)
+                        } else if torrent.isStuck {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                                .font(.title3)
+                        }
                     }
                     .contentShape(Rectangle())
                 }
@@ -129,16 +140,4 @@ struct DebridFilesView: View {
         }
     }
 
-    private func statusColor(for status: String) -> Color {
-        switch status {
-        case "downloaded":
-            return .green
-        case "downloading":
-            return .blue
-        case "seeding":
-            return .orange
-        default:
-            return .gray
-        }
-    }
 }

--- a/Dionysus/FilesDetailView.swift
+++ b/Dionysus/FilesDetailView.swift
@@ -17,7 +17,28 @@ struct FileDetailsView: View {
                         }
                     }
                 } else if let torrentInfo = viewModel.torrentInfo {
-                    List(torrentInfo.files) { file in
+                    List {
+                        if torrent.isFailed || torrent.isStuck {
+                            Section {
+                                HStack(alignment: .top, spacing: 12) {
+                                    Image(systemName: torrent.isFailed ? "exclamationmark.circle.fill" : "exclamationmark.triangle.fill")
+                                        .foregroundColor(torrent.isFailed ? .red : .orange)
+                                        .font(.title3)
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(torrent.statusLabel)
+                                            .font(.headline)
+                                            .foregroundColor(torrent.isFailed ? .red : .orange)
+                                        Text(torrent.isFailed
+                                            ? "This torrent failed on Real-Debrid. Delete it and re-add a different source."
+                                            : "Files were never selected — this torrent is stuck. Delete it and re-add.")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                        ForEach(torrentInfo.files) { file in
                         HStack(spacing: 10) {
                             Image(systemName: file.isSubtitle ? "captions.bubble.fill" : "doc.fill")
                                 .foregroundColor(file.isSubtitle ? .green : .secondary)
@@ -37,6 +58,7 @@ struct FileDetailsView: View {
                                     }
                                 }
                             }
+                        }
                         }
                     }
                 } else {

--- a/Dionysus/SharedCode.swift
+++ b/Dionysus/SharedCode.swift
@@ -250,6 +250,40 @@ struct RealDebridTorrent: Codable, Identifiable {
     let status: String
 }
 
+extension RealDebridTorrent {
+    var isFailed: Bool {
+        ["error", "dead", "virus", "magnet_error"].contains(status)
+    }
+    var isStuck: Bool {
+        status == "waiting_files_selection"
+    }
+    var statusLabel: String {
+        switch status {
+        case "downloaded":     return "Ready"
+        case "downloading":    return "Downloading"
+        case "queued":         return "Queued"
+        case "compressing":    return "Compressing"
+        case "uploading":      return "Uploading"
+        case "waiting_files_selection": return "Stuck — files not selected"
+        case "magnet_conversion":       return "Resolving magnet"
+        case "error":          return "Failed — re-add recommended"
+        case "dead":           return "Dead torrent — no seeders"
+        case "virus":          return "Blocked — flagged as malware"
+        case "magnet_error":   return "Invalid magnet link"
+        default:               return status
+        }
+    }
+    var statusColor: Color {
+        if isFailed { return .red }
+        if isStuck  { return .orange }
+        switch status {
+        case "downloaded": return .green
+        case "downloading", "queued", "compressing", "uploading": return .blue
+        default: return .secondary
+        }
+    }
+}
+
 struct RealDebridFile: Codable, Identifiable, Hashable {
     let id: Int
     let path: String


### PR DESCRIPTION
## Summary

- **List view**: each torrent row now shows a red `exclamationmark.circle.fill` for failed torrents (error/dead/virus/magnet_error) or an orange triangle for stuck ones (waiting_files_selection). Status text is human-readable instead of raw RD strings.
- **Detail view**: a banner appears at the top when the torrent has a bad status, telling you what's wrong and to delete + re-add.

Status labels:
| RD status | Label shown |
|---|---|
| `downloaded` | Ready |
| `error` | Failed — re-add recommended |
| `dead` | Dead torrent — no seeders |
| `virus` | Blocked — flagged as malware |
| `magnet_error` | Invalid magnet link |
| `waiting_files_selection` | Stuck — files not selected |

## Test plan

- [ ] Torrent with status `error` shows red icon in list + banner in detail
- [ ] Torrent with status `downloaded` shows green "Ready" with no icon
- [ ] Torrent stuck at `waiting_files_selection` shows orange triangle

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg)_