### PR TITLE
Per-file copyright/health check in file detail view

### DIFF
--- a/Dionysus/FilesDetailView.swift
+++ b/Dionysus/FilesDetailView.swift
@@ -57,6 +57,27 @@ struct FileDetailsView: View {
                                             .foregroundColor(.green)
                                     }
                                 }
+                                if let health = viewModel.fileHealth[file.id] {
+                                    switch health {
+                                    case .checking:
+                                        HStack(spacing: 4) {
+                                            ProgressView().scaleEffect(0.6)
+                                            Text("Checking…")
+                                                .font(.caption2)
+                                                .foregroundColor(.secondary)
+                                        }
+                                    case .infringing:
+                                        Label("Blocked — copyright claim", systemImage: "exclamationmark.circle.fill")
+                                            .font(.caption2)
+                                            .foregroundColor(.red)
+                                    case .failed:
+                                        Label("Couldn't verify link", systemImage: "exclamationmark.triangle.fill")
+                                            .font(.caption2)
+                                            .foregroundColor(.orange)
+                                    case .ok:
+                                        EmptyView()
+                                    }
+                                }
                             }
                         }
                         }

--- a/Dionysus/FilesDetailViewModel.swift
+++ b/Dionysus/FilesDetailViewModel.swift
@@ -3,22 +3,57 @@ import SwiftUI
 
 @MainActor
 class FileDetailsViewModel: ObservableObject {
+    enum FileHealth { case checking, ok, infringing, failed }
+
     @Published var torrentInfo: RealDebridTorrentInfo?
     @Published var isLoading = false
     @Published var errorMessage: String?
-    
+    @Published var fileHealth: [Int: FileHealth] = [:]
+
     func fetchDetails(id: String) async {
         isLoading = true
         errorMessage = nil
-        
+
         do {
-            self.torrentInfo = try await APIService.shared.fetchTorrentInfo(id: id)
+            let info = try await APIService.shared.fetchTorrentInfo(id: id)
+            self.torrentInfo = info
+            isLoading = false
+            await checkFileHealth(for: info)
         } catch let apiError as APIError {
             self.errorMessage = apiError.localizedDescription
+            isLoading = false
         } catch {
             self.errorMessage = "Failed to load file details: \(error.localizedDescription)"
+            isLoading = false
         }
-        
-        isLoading = false
+    }
+
+    private func checkFileHealth(for info: RealDebridTorrentInfo) async {
+        guard info.status == "downloaded" else { return }
+        let selectedFiles = info.files.filter { $0.selected == 1 }
+        guard selectedFiles.count == info.links.count, !info.links.isEmpty else { return }
+
+        for file in selectedFiles {
+            fileHealth[file.id] = .checking
+        }
+
+        await withTaskGroup(of: (Int, FileHealth).self) { group in
+            for (index, file) in selectedFiles.enumerated() {
+                let link = info.links[index]
+                group.addTask {
+                    do {
+                        _ = try await APIService.shared.unrestrict(link: link)
+                        return (file.id, .ok)
+                    } catch APIError.infringingFile {
+                        return (file.id, .infringing)
+                    } catch {
+                        return (file.id, .failed)
+                    }
+                }
+            }
+            for await (fileId, health) in group {
+                self.fileHealth[fileId] = health
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

After loading a torrent's file list, unrestricts each download link in parallel and shows the result inline under each filename:

- **Checking…** — spinner while links are being verified
- **Blocked — copyright claim** (red) — RD returned 451 infringing_file for that specific file
- **Couldn't verify link** (orange) — some other error on that link
- Nothing for healthy files (no noise)

This surfaces the case where a torrent shows "downloaded" but individual files are DMCA-blocked by RD, causing empty folders in Infuse.

## Test plan

- [ ] Open a known-good torrent — files show no indicator after checking
- [ ] Open a torrent with a DMCA-blocked file — red "Blocked — copyright claim" appears under affected file(s)
- [ ] RAR or mismatched link count — check is skipped silently (links count != selected files count)

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg)_