### PR TITLE
Bump RD library state after confirm to trigger Infuse rescan

### DIFF
--- a/Dionysus/MovieLibraryApp.swift
+++ b/Dionysus/MovieLibraryApp.swift
@@ -329,6 +329,9 @@ class LibraryViewModel: ObservableObject {
             existingTorrentHashes.insert(info.hash.lowercased())
             addState = .success
             HapticManager.shared.success()
+            // Silently add+delete a dummy entry to bump the RD library state,
+            // so Infuse detects a change and rescans, picking up the real item.
+            Task.detached { await APIService.shared.addDummyAndDelete() }
         } catch {
             addState = .error
         }

--- a/Dionysus/SharedCode.swift
+++ b/Dionysus/SharedCode.swift
@@ -630,6 +630,20 @@ class APIService {
         return (added.id, info)
     }
 
+    func addDummyAndDelete() async {
+        // Syntactically valid but unresolvable hash — RD still creates the entry (201),
+        // changing the library state so Infuse detects a diff on its next scan.
+        let dummy = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000&dn=dummy"
+        do {
+            let added = try await addMagnetToRealDebrid(magnet: dummy)
+            // Give Infuse enough time to pick up the change on its next poll
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            try? await deleteTorrent(id: added.id)
+        } catch {
+            // Best-effort — silently ignore failures
+        }
+    }
+
     func confirmTorrentSelection(id: String) async throws {
         try await selectTorrentFiles(torrentId: id)
     }


### PR DESCRIPTION
## Summary

Workaround for Infuse being "one source behind" on Apple TV.

After a torrent is confirmed, a detached background task silently adds a zero-hash dummy magnet to Real-Debrid (`0000000000000000000000000000000000000000`) and deletes it 5 seconds later. RD still creates the entry (HTTP 201), which changes the library state enough for Infuse to detect a diff and rescan — picking up the real item at the same time.

- Fully silent, no UI change
- Detached task so it doesn't block the success state
- Failures are swallowed — it's best-effort

## Test plan
- [ ] Add a torrent, confirm it, then immediately trigger "Scan for Changes" in Infuse — new item should appear without needing to add another real torrent first

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg)_