### PR TITLE
Surface Real-Debrid cache status in search results

### DIFF
--- a/Dionysus/MovieLibraryApp.swift
+++ b/Dionysus/MovieLibraryApp.swift
@@ -133,7 +133,7 @@ class LibraryViewModel: ObservableObject {
         }
     }
 
-    func fetchTorrents(for query: String, forceRefresh: Bool = false) async {
+    func fetchTorrents(for query: String, tmdbId: Int? = nil, forceRefresh: Bool = false) async {
         isLoading = true
         isWakingServer = false
         errorMessage = nil
@@ -147,7 +147,7 @@ class LibraryViewModel: ObservableObject {
                 try? await Task.sleep(nanoseconds: retryDelays[attempt - 1])
             }
             do {
-                async let searchResult = APIService.shared.searchTorrents(query: query, forceRefresh: forceRefresh)
+                async let searchResult = APIService.shared.searchTorrents(query: query, tmdbId: tmdbId, forceRefresh: forceRefresh)
                 async let hashesResult = APIService.shared.fetchUserTorrentHashes()
                 let (fetchedTorrents, fetchedHashes) = try await (searchResult, hashesResult)
                 self.torrents = fetchedTorrents
@@ -665,6 +665,12 @@ struct MediaDetailView: View {
         (media is TVShow) ? "\(media.title) complete" : "\(media.title) \(releaseYear)"
     }
 
+    // Only movies benefit from backend cache detection (Torrentio's movie endpoint).
+    // TV searches omit the id and fall back to scraper-only results.
+    private var movieTmdbId: Int? {
+        (media as? Movie)?.id
+    }
+
     private var watchStatus: WatchStatus {
         if let movie = media as? Movie {
             return traktService.watchedMovieIDs.contains(movie.id) ? .completed : .unwatched
@@ -746,7 +752,7 @@ struct MediaDetailView: View {
             mainDetailContent
                 .frame(maxWidth: .infinity)
 
-            SourcesView(searchQuery: searchQuery)
+            SourcesView(searchQuery: searchQuery, tmdbId: movieTmdbId)
                 .frame(maxWidth: 450)
                 .background(.black.opacity(0.2))
         }
@@ -784,7 +790,7 @@ struct MediaDetailView: View {
         }
         .sheet(item: $librarySearchQuery) { query in
             NavigationStack {
-                SourcesView(searchQuery: query)
+                SourcesView(searchQuery: query, tmdbId: movieTmdbId)
             }.presentationDetents([.medium, .large])
         }
         .toolbar(.hidden, for: .navigationBar)
@@ -978,6 +984,7 @@ struct WatchProvidersView: View {
 struct SourcesView: View {
     @StateObject private var viewModel = LibraryViewModel()
     let searchQuery: String
+    var tmdbId: Int? = nil
 
     @State private var selectedQuality: String = "All"
     @State private var selectedAVQuality: AVQuality = .normal
@@ -985,8 +992,11 @@ struct SourcesView: View {
     @State private var selectedProvider: String = "All"
     @State private var queryInput: String = ""
     @State private var lastSubmittedQuery: String = ""
+    @State private var instantOnly: Bool = false
 
     private let qualityOptions = ["All", "2160p", "1080p", "720p"]
+
+    private var cachedCount: Int { viewModel.torrents.filter { $0.rdCached == true }.count }
 
     private var finalSearchQuery: String {
         var query = lastSubmittedQuery.isEmpty ? searchQuery : lastSubmittedQuery
@@ -1000,6 +1010,7 @@ struct SourcesView: View {
 
     private var filteredTorrents: [Torrent] {
         var torrents = viewModel.torrents.filter { $0.magnet != nil }
+        if instantOnly { torrents = torrents.filter { $0.rdCached == true } }
         if selectedQuality != "All" { torrents = torrents.filter { $0.quality == selectedQuality } }
         if selectedProvider != "All" { torrents = torrents.filter { $0.provider == selectedProvider } }
         if !filterText.isEmpty { torrents = torrents.filter { $0.name.localizedCaseInsensitiveContains(filterText) } }
@@ -1042,6 +1053,14 @@ struct SourcesView: View {
                         .padding(8)
                         .background(Color(.systemGray6))
                         .cornerRadius(10)
+                    if cachedCount > 0 {
+                        Toggle(isOn: $instantOnly) {
+                            Label("Instant only — \(cachedCount) cached", systemImage: "bolt.fill")
+                                .font(.custom("Eurostile-Regular", size: 14))
+                                .foregroundColor(.yellow)
+                        }
+                        .tint(.yellow)
+                    }
                 }
                 .padding(.horizontal)
                 .padding(.top)
@@ -1058,7 +1077,7 @@ struct SourcesView: View {
                             }
                         }
                     }
-                    else if let errorMessage = viewModel.errorMessage { ErrorView(message: errorMessage) { Task { await viewModel.fetchTorrents(for: finalSearchQuery) } } }
+                    else if let errorMessage = viewModel.errorMessage { ErrorView(message: errorMessage) { Task { await viewModel.fetchTorrents(for: finalSearchQuery, tmdbId: tmdbId) } } }
                     else if filteredTorrents.isEmpty { ContentUnavailableView("No Sources Found", systemImage: "magnifyingglass") }
                     else {
                         List(filteredTorrents) { torrent in
@@ -1083,10 +1102,10 @@ struct SourcesView: View {
                 }
             }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button { Task { await viewModel.fetchTorrents(for: finalSearchQuery, forceRefresh: true) } } label: { Label("Refresh", systemImage: "arrow.clockwise") }
+                    Button { Task { await viewModel.fetchTorrents(for: finalSearchQuery, tmdbId: tmdbId, forceRefresh: true) } } label: { Label("Refresh", systemImage: "arrow.clockwise") }
                 }
             }
-            .task(id: finalSearchQuery) { await viewModel.fetchTorrents(for: finalSearchQuery, forceRefresh: false) }
+            .task(id: finalSearchQuery) { await viewModel.fetchTorrents(for: finalSearchQuery, tmdbId: tmdbId, forceRefresh: false) }
             .onAppear {
                 queryInput = searchQuery
                 lastSubmittedQuery = searchQuery
@@ -1333,6 +1352,14 @@ struct TorrentRowView: View {
                 HStack {
                     Text(torrent.provider ?? "Unknown").font(.custom("Eurostile-Regular", size: 12)).padding(.horizontal, 8).padding(.vertical, 4).background(Color.blue.opacity(0.3)).cornerRadius(8)
                     if let quality = torrent.quality { Text(quality).font(.custom("Eurostile-Regular", size: 12)).padding(.horizontal, 8).padding(.vertical, 4).background(Color.purple.opacity(0.3)).cornerRadius(8) }
+                    if torrent.rdCached == true {
+                        Label("Instant", systemImage: "bolt.fill")
+                            .font(.custom("Eurostile-Regular", size: 12))
+                            .padding(.horizontal, 8).padding(.vertical, 4)
+                            .background(Color.yellow.opacity(0.25))
+                            .foregroundColor(.yellow)
+                            .cornerRadius(8)
+                    }
                     Spacer()
                 }
                 HStack(spacing: 4) {

--- a/Dionysus/SharedCode.swift
+++ b/Dionysus/SharedCode.swift
@@ -103,6 +103,7 @@ struct Video: Codable, Identifiable {
 
 struct TorrentResponse: Codable {
     let data: [Torrent]
+    let rdCachedCount: Int?
 }
 
 struct Torrent: Codable, Identifiable, Hashable {
@@ -114,8 +115,15 @@ struct Torrent: Codable, Identifiable, Hashable {
     let magnet: String?
     let quality: String?
     let provider: String?
+    // Real-Debrid cache flag from the backend. true = cached (safe to add),
+    // false = not cached, nil = unknown (no RD token sent or hash unresolvable).
+    let rdCached: Bool?
+    // Torrentio's index of the target video file within the torrent, if known.
+    let fileIdx: Int?
+    // Info-hash provided directly by the backend; preferred over magnet parsing.
+    private let providedInfoHash: String?
 
-    init(name: String, size: String?, seeders: String?, leechers: String?, magnet: String?, quality: String?, provider: String?) {
+    init(name: String, size: String?, seeders: String?, leechers: String?, magnet: String?, quality: String?, provider: String?, rdCached: Bool? = nil, fileIdx: Int? = nil, providedInfoHash: String? = nil) {
             self.name = name
             self.size = size
             self.seeders = seeders
@@ -123,10 +131,15 @@ struct Torrent: Codable, Identifiable, Hashable {
             self.magnet = magnet
             self.quality = quality
             self.provider = provider
+            self.rdCached = rdCached
+            self.fileIdx = fileIdx
+            self.providedInfoHash = providedInfoHash
         }
 
     enum CodingKeys: String, CodingKey {
         case name, size, seeders, leechers, magnet, quality, provider
+        case rdCached, fileIdx
+        case providedInfoHash = "infoHash"
     }
 
     init(from decoder: Decoder) throws {
@@ -137,6 +150,9 @@ struct Torrent: Codable, Identifiable, Hashable {
         magnet = try container.decodeIfPresent(String.self, forKey: .magnet)
         quality = try container.decodeIfPresent(String.self, forKey: .quality)
         provider = try container.decodeIfPresent(String.self, forKey: .provider)
+        rdCached = try container.decodeIfPresent(Bool.self, forKey: .rdCached)
+        fileIdx = try container.decodeIfPresent(Int.self, forKey: .fileIdx)
+        providedInfoHash = try container.decodeIfPresent(String.self, forKey: .providedInfoHash)?.lowercased()
 
         do {
             seeders = try container.decodeIfPresent(String.self, forKey: .seeders)
@@ -159,8 +175,9 @@ struct Torrent: Codable, Identifiable, Hashable {
         }
     }
 
-    
+
     var infoHash: String? {
+        if let providedInfoHash, !providedInfoHash.isEmpty { return providedInfoHash }
         guard let magnet = magnet,
               let range = magnet.range(of: "urn:btih:") else { return nil }
         let hashStartIndex = range.upperBound
@@ -527,11 +544,14 @@ class APIService {
         return response.results.filter { $0.site == "YouTube" }
     }
 
-    func searchTorrents(query: String, forceRefresh: Bool = false) async throws -> [Torrent] {
+    func searchTorrents(query: String, tmdbId: Int? = nil, forceRefresh: Bool = false) async throws -> [Torrent] {
         let torrentApiUrl = "https://dionysus-server-py-production.up.railway.app"
         let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
 
         var urlString = "\(torrentApiUrl)/api/v1/all/search?query=\(encodedQuery)"
+        if let tmdbId {
+            urlString += "&tmdb_id=\(tmdbId)"
+        }
         if forceRefresh {
             urlString += "&force_refresh=true"
         }
@@ -539,10 +559,17 @@ class APIService {
         print("[API] Searching torrents: \(urlString)")
         let url = URL(string: urlString)!
 
+        var request = URLRequest(url: url)
+        // Send the user's RD token so the backend can tag results as cached.
+        let rdToken = SettingsManager.shared.realDebridApiKey
+        if !rdToken.isEmpty {
+            request.setValue(rdToken, forHTTPHeaderField: "X-RD-Token")
+        }
+
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(from: url)
+            (data, response) = try await URLSession.shared.data(for: request)
         } catch let urlError as URLError where urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost {
             throw APIError.networkUnavailable
         }


### PR DESCRIPTION
## Summary

Frontend integration for the backend's new Real-Debrid cache detection (Torrentio-backed). This addresses the ~90% `451 infringing_file` failure rate by showing which results are already cached on RD (and therefore safe to add instantly).

### Changes
- **`searchTorrents`** now sends `tmdb_id` (movies only) and the `X-RD-Token` header so the backend can tag results with cache status
- **`Torrent` model** decodes the new fields: `rdCached`, `fileIdx`, and the backend-provided `infoHash` (now preferred over magnet parsing, with fallback)
- **`TorrentResponse`** decodes `rdCachedCount`
- **⚡ Instant badge** (yellow) on cached rows
- **"Instant only" toggle** — appears when cached results exist, filters to `rdCached == true`, shows the cached count
- `tmdbId` threaded from `MediaDetailView` (movies only) → `SourcesView` → `fetchTorrents`. TV searches omit it and behave exactly as before.

### Notes
- Per the backend doc, only **movies** get cache enrichment (Torrentio's movie endpoint). TV still returns scraper-only results — `tmdbId` is `nil` for shows/episodes.
- Absent `rdCached` is treated as **unknown** (no badge), so behavior is unchanged when no RD token is connected.
- The endpoint takes `tmdb_id` (the backend resolves it to IMDB internally) — there's no separate `imdb_id` param in the documented contract.

## Test plan
- [ ] Search a movie with RD connected — cached results show ⚡ Instant badge and sort to top
- [ ] "Instant only" toggle appears and filters correctly
- [ ] Adding a cached (⚡) result succeeds without a 451
- [ ] TV show search still returns results (no badge, no regression)
- [ ] No RD token connected — search still works, no badges

https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYiHuEAxAVwvvFHEddx8kg)_